### PR TITLE
Remodel test for/against info-expand button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9081,6 +9081,10 @@
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
       "dev": true
     },
+    "phantomjs-polyfill-find": {
+      "version": "github:ptim/phantomjs-polyfill-find#026b69dcabe743265f5214775e42f8d1e8aabedc",
+      "dev": true
+    },
     "phantomjs-prebuilt": {
       "version": "2.1.16",
       "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",


### PR DESCRIPTION
The MetadataList.vue component has had several flaws, such as accessing DOM elements at a stage where DOM elements are being rendered, and re-calculating if expand buttons are needed too seldom. 
Calculating if an expand button is needed has been based on the height of DOM elements that might have to be collapsed. However, this method should logically be called at a stage where the DOM tree is still being generated. Secondly, the calculation method is called in mounted(), and thus only at chapter breaks, whereas logically it should be executed each time metadata changes. 

These flaws might have led to expand buttons inconsistently rendered without real need to toggle expand/ collapse text blocks.

Due to limitations exposed by the Vue.js Lifecycle it is not possible to fix the method as is. While the calculation should be logically called on updated() instead of on mounted() this is not possible at all: as it updates infoItems it would issue itself to be called again in an infinite loop. There is no solution for the problem of accessing DOM elements before the DOM is being rendered other than simply not doing it.

Instead I propose a different solution based on the metadata's values and fixed heights: Adopt line heights and average number of characters fitting each line from the CSS and empirical observations, respectively, and calculate the need for an expand button based on the expected heights of metadata elements. This method comes with its own flaws, by definition it is neither responsive nor reacts to zoom factors. However, I have tested it to work reasonably well with both: both display sizes and text zoom change the number of characters fitting into each line only so much, and the values I have set accommodate these changes. Please note that for small displays and extremely low zooming factors we will again see expand buttons rendered without real need. 

In addition, I've registered a watcher to initiate re-calculating the need for expand buttons each time metadata changes. 

Overall, I believe the proposed solution to be a real advantage compared to the present solution: it not only ensures heights are re-calculated on every metadata change, it also introduces reliable behavior optimized for most display sizes and zoom factors.