### PR TITLE
Trigger correct TOC element by collapse button

### DIFF
--- a/src/components/TocList.vue
+++ b/src/components/TocList.vue
@@ -1,13 +1,14 @@
 <template>
 	<ul class="tify-toc_list">
 		<li
-			v-for="structure, index in structures"
+			v-for="(structure, index) in structures"
 			class="tify-toc_structure"
 			:data-level="level"
 			:class="{
 				'-current': checkIfPagesInStructure(structure),
 				'-expanded': expandedStructures[index],
 			}"
+			:key="index"
 		>
 			<button
 				v-if="structure.childStructures"
@@ -99,7 +100,7 @@
 				if (doExpand) {
 					this.$set(this.expandedStructures, index, true);
 				} else {
-					this.$delete(this.expandedStructures, index);
+					this.$set(this.expandedStructures, index, false);
 				}
 			},
 		},

--- a/test/e2e/specs/toc.spec.js
+++ b/test/e2e/specs/toc.spec.js
@@ -36,6 +36,11 @@ Scenario('Navigate TOC', (I) => {
 	I.dontSee('Auflösung von Gleichungen 3ten Grades');
 	I.dontSee('Recursionsformeln');
 
+	I.click('Expand all');
+	I.click('.tify-toc_toggle:first-of-type'); // collapse first collapsible
+	I.dontSee('Auflösung von Gleichungen 3ten Grades'); // child of first collapsible
+	I.see('Recursionsformeln'); // child of second collapsible
+
 	// Browser may be "restarted" between tests, but window size is not reset.
 	I.resizeWindow(800, 600);
 });


### PR DESCRIPTION
Collapse/expand buttons in the table of content did not work as expected: when expanding two elements and subsequently collapsing the first, the first element remained expaned while the second was collapsed. This bug is fixed in the present pull request.