### PR TITLE
Use node's replace command for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "AGPL-3.0",
   "scripts": {
     "postinstall": "rimraf openseadragon && git clone https://github.com/openseadragon/openseadragon.git && cd openseadragon && git checkout tags/v2.4.1 && cd .. && npm run fix-openseadragon",
-    "fix-openseadragon": "replace '\\}\\(this, function \\(\\) \\{' '}(window, function () {' ./openseadragon/src/openseadragon.js",
+    "fix-openseadragon": "./node_modules/.bin/replace '\\}\\(this, function \\(\\) \\{' '}(window, function () {' ./openseadragon/src/openseadragon.js",
     "dev": "webpack-dev-server --inline --progress --config build/webpack.dev.conf.js",
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs",
     "build": "node build/build.js",


### PR DESCRIPTION
As Windows has a 'replace' command built in, it is now assured, that the
node 'replace' command is used.