### PR TITLE
Add support for empty ranges

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
 		}],
 		'indent': [2, 'tab'],
 		// allow debugger during development
+		'no-continue': 0,
 		'no-debugger': process.env.NODE_ENV === 'production' ? 2 : 0,
 		'no-floating-decimal': 0,
 		'no-tabs': 0,

--- a/src/mixins/structures.js
+++ b/src/mixins/structures.js
@@ -24,8 +24,14 @@ module.exports = {
 					const lastCanvas = structure.canvases[structure.canvases.length - 1];
 					structure.lastPage = this.$root.canvases.findIndex(canvas => canvas['@id'] === lastCanvas) + 1;
 
-					structure.pageLabel = this.$root.canvases[structure.firstPage - 1].label;
-				} else {
+					const firstPageCanvas = this.$root.canvases[structure.firstPage - 1];
+					if (!firstPageCanvas) {
+						// Excluding structure if its range has no canvases
+						continue;
+					}
+
+					structure.pageLabel = firstPageCanvas.label;
+				} else if (this.$root.canvases[0]) {
 					structure.firstPage = 1;
 					structure.lastPage = this.$root.pageCount;
 					structure.pageLabel = this.$root.canvases[0].label;

--- a/test/e2e/specs/toc.spec.js
+++ b/test/e2e/specs/toc.spec.js
@@ -44,3 +44,16 @@ Scenario('Navigate TOC', (I) => {
 	// Browser may be "restarted" between tests, but window size is not reset.
 	I.resizeWindow(800, 600);
 });
+
+Scenario('Show TOC when there are structures without canvases', (I) => {
+	const params = {
+		view: 'toc',
+	};
+	const encodedParams = encodeURIComponent(JSON.stringify(params));
+
+	I.amOnPage(`http://localhost:8080/?manifest=http://localhost:8081/manifest/MS-ADD-08640.json&tify=${encodedParams}`);
+	I.waitForElement('.tify-app_main');
+
+	I.see('Table of Contents');
+	I.see('Elizabeth Lyttelton\'s commonplace book', '.tify-toc_structure.-current');
+});

--- a/test/iiif-api/data/manifests/MS-ADD-08640.json
+++ b/test/iiif-api/data/manifests/MS-ADD-08640.json
@@ -1,0 +1,5227 @@
+{
+	"viewingDirection": "left-to-right",
+	"metadata": [
+		{
+			"label": "Binding",
+			"value": "<p>Scuffed contemporary brown sheep, with double blind-tooled ruling.<\/p> No label to the spine.<br /> <p>The manuscript is now preserved in a modern slipcase of light-brown russia with a green ribbon.<\/p> On the spine of the slip-case there is written in gold lettering, 'elizabeth lyttelton's common-place book', and a shelf mark in pen and ink, 'Add 8460'."
+		},
+		{
+			"label": "Condition",
+			"value": "<p>The manuscript is mostly in a good condition, with no damage to the text block, but slight damage to the front and back endleaves.<\/p> <p>All pages are stained at the outer margins, the 'beginning' and 'end' of the manuscript more heavily so.<\/p> <p>Several pages (e.g. <a href='' onclick='store.loadPage(35);return false;'>pp. 33-44<\/a> and <a href='' onclick='store.loadPage(108);return false;'>pp. 106-99<\/a>) have come loose from the binding. This is apparent in many of the images.<\/p>"
+		},
+		{
+			"label": "Script",
+			"value": "<div style='list-style-type: disc;'> <div style='display: list-item; margin-left: 20px;'> <p>Items 1-37, 39, and 47-97 are written in Lyttelton's hand. This is a characteristic late seventeenth-century <i>round<\/i> hand. Two distinct phases in her penmanship can be discerned, corresponding to two different periods of entry. The earlier entries are in a lighter brown ink and neater, whilst later entries are in a darker ink and scratchier. The later entries include the title 'Queen Elizas answer to Bishop Gardner' at <a href='' onclick='store.loadPage(19);return false;'>p. 17<\/a>; the four poems by John Norris at <a href='' onclick='store.loadPage(12);return false;'>p. 10<\/a>, <a href='' onclick='store.loadPage(16);return false;'>p. 14<\/a>, <a href='' onclick='store.loadPage(24);return false;'>p. 22<\/a>, and <a href='' onclick='store.loadPage(26);return false;'>p. 24<\/a>; the epitaph on her mother Dorothy Browne, who died in 1685, at <a href='' onclick='store.loadPage(105);return false;'>p. 103<\/a>; and brief notes on St Andrew, St James, and St Peter, which she added below an entry copied by the original owner, at <a href='' onclick='store.loadPage(105);return false;'>p. 103<\/a>. The earlier entries include religious verse, extracts from the classics, and fragments from her father Sir Thomas Browne's writings, whilst the later entries are a broader mixture of religious and secular poetry and prose.<\/p> <p>At various points in the manuscript (e.g., <a href='' onclick='store.loadPage(29);return false;'>pp. 27-28<\/a>) Lyttelton also used a less formal, correcting hand. This has fewer flourishes, and the graphs are smaller. She also used this hand to add headings at a couple of places: 'sen. Res severa et verum gaudium ' (<a href='' onclick='store.loadPage(25);return false;'>p. 23<\/a>) and 's<sup>t<\/sup> Aug. climarum ' (<a href='' onclick='store.loadPage(30);return false;'>p. 28<\/a>). This correcting hand probably dates from the second phase of her penmanship.<\/p> <p>Punctuation erratic, but not unusually so; stanza divisions and ends of entries sometimes marked with horizontal lines.<\/p> <p>Light use of abbreviation: \"y<sup>e<\/sup>\" for \"the\" and \"y<sup>m<\/sup>\" for \"them\", and frequent use of superscript letters and contractions ('S<sup>r<\/sup>', 'D<sup>r<\/sup>', etc.). Latin entries often show an abbreviation of the final consonant (using a tilde or \"circumflex\" mark).<\/p> <\/div> <div style='display: list-item; margin-left: 20px;'> <p>Items 38, 40, 41, 42, 43, 44, 45, and 46 were copied by the original owner of the manuscript, and are in a more cursive <i>round<\/i> hand. Characteristic features of this hand include the pronounced looping descenders on infralinear graphs (\"f\", \"g\", \"p\", long \"s\", and \"y\") and the long cross strokes on \"t\" and \"f\". The strokes are also more lightly inked than Lyttelton's, perhaps reflecting the status of these items as sermon notes. The orthography is also extremely idiosyncratic. Until recently, this hand was unidentified, and scholars simply referred to the items collectively as 'Sermon notes and homilies'. However, Dr Rebecca Bullard of Merton College, Oxford, has identified this hand as Dorothy Browne's, wife of Sir Thomas Browne, and mother of Elizabeth Lyttelton. We are indebted to Dr Bullard for sharing this discovery with us (personal communication, 20 November 2008).<\/p> <\/div> <\/div>"
+		},
+		{
+			"label": "Origin Place",
+			"value": "England"
+		},
+		{
+			"label": "Provenance",
+			"value": "<p>The manuscript, and copyist of the sermon notes and homilies (<a href='' onclick='store.loadPage(161);return false;'>pp. 170-104, p. 102<\/a>), originally belonged to Lady Dorothy Browne (d. 1685), wife of Sir Thomas Browne, and mother of Elizabeth Lyttelton.<\/p> <p>At some point, the manuscript then passed to Elizabeth Lyttelton (b. c. 1648, d. after 1728), third of the seven daughters of Thomas and Dorothy Browne. Elizabeth later gave the manuscript to her cousin Edward Tenison (bap. 1673, d. 1735), prebendary of Canterbury, and afterwards bishop of Ossory, as a note on the back flyleaf indicates: 'Mar. 11<sup>th<\/sup> 1713/4 The gift of Mrs Lyttelton to Edward Tenison' (<a href='' onclick='store.loadPage(176);return false;'>p. 174<\/a>). On front and back flyleaves (<a href='' onclick='store.loadPage(3);return false;'>p. 1<\/a> and <a href='' onclick='store.loadPage(176);return false;'>p. 174<\/a>) signatures of Mary Browne, Elizabeth's younger sister, and also 'Ja<sup>s<\/sup> Dodsley', presumably a later owner of the manuscript.<\/p> <p>Purchased by Geoffrey Keynes for three guineas during the First World War (<i>Bibliotheca Bibliographici<\/i>, no. 1301) and published by him in 1919. Presented, with his Browne collection, to the Royal College of Physicians (with their bookplate and Keynes\u2019s \u2018ex dono\u2019 label) in 1975. Later (before his death in 1982) Keynes requested that the collection be sold to the University of Cambridge to benefit the College building fund.<\/p>"
+		},
+		{
+			"label": "Physical Location",
+			"value": "Cambridge University Library"
+		},
+		{
+			"label": "Extent",
+			"value": "174 pages (pp. 174-46 reversed) height: 204 mm, width: 165 mm."
+		},
+		{
+			"label": "Funding",
+			"value": "Arts and Humanities Research Council"
+		},
+		{
+			"label": "Date of Creation",
+			"value": "1670-1714"
+		},
+		{
+			"label": "Associated Person(s)",
+			"value": "Alabaster, William, Dr; Queen Anne; Aleyn, Charles; Behn, Aphra; Boyle, Robert; Browne, Dorothy, Lady; Browne, Edward, Dr; Browne, Mary; Browne, Thomas, Sir; Browne, William; Carey, Thomas; Carr, Robert, Earl of Somerset; Cartwright, William; Corbett, Richard; Corbett, Vincent; Corbett, Vincent; Dekker, Thomas; Dr Dillingham; Donne, John; Du Bartas, Guillaume; Queen Elizabeth I; Elys, Edmund; Dr Evans; Fairfax, William; Fanshawe, Richard; Felton, John; Flatman, Thomas; Fuller, Thomas; Herbert, Mary, Countess of Pembroke; Doctor Hewyt; Heylyn, Peter; Heywood, Thomas; Foxe, John; Grey, Jane, Lady; King Charles I; King James 1; Lipsius, Justus; Luther, Martin; Lully, Jean-Baptiste; Lyttelton, Elizabeth; Lyttelton, George; Mill, Walter; Morton, Albertus, Sir; Munday, Anthony; Norris, John; Philips, Katherine; Quinault, Philippe; Ralegh, Walter; Reynolds, Edward, Bishop of Norwich; Prince Rupert; Sacheverell, Henry, Dr; Savile, Henry; Scroggs, William, Lord Chief Justice; Sidney, Philip, Sir; Stow, John; Sylvester, Joshua; Taylor, John; Tenison, Edward, Bishop of Ossory; Villiers, George, first Duke of Buckingham; Villiers, George, second Duke of Buckingham; Wanley, Nathaniel; Wilmot, John, Earl of Rochester; Woodhouse, Philip, Sir; Wotton, Henry; Gardiner, Stephen, Bishop of Winchester; Rycaut, Paul; Semedo, Alvaro, S. J.; Baker, Richard, Sir; Olearius, Adam; Tavernier, Jean-Baptiste; della Valle, Pietro; Le Blanc, Vincent; Mendes Pinto, Fernão; Gage, Thomas; Camden, William; Sandys, George; Magnus, Olaus; Speed, John; Purchas, Samuel; Boatman, John"
+		},
+		{
+			"label": "Title",
+			"value": "Elizabeth Lyttelton's commonplace book; English, French, and Latin; 1670s-1713."
+		},
+		{
+			"label": "Material",
+			"value": "<p> Paper <\/p>"
+		},
+		{
+			"label": "Collation",
+			"value": "<p>I:8 [wants 3 (though this remains as a stub between pp. 4 and 5); includes front endleaf, which forms physical part of gathering], II-X:8, XI:8 [includes back endleaf, which forms physical part of gathering]<\/p>"
+		},
+		{
+			"label": "Classmark",
+			"value": "UL MS Add. 8460"
+		},
+		{
+			"label": "Note(s)",
+			"value": "A terminus ad quem is provided by the latest item in the manuscript chronologically, 'The humble Addres of y<sup>e<\/sup> house of Commons to the Queen, March y<sup>e<\/sup> 7 1710' (<a href='' onclick='store.loadPage(73);return false;'>p. 71<\/a>), the petition of the House of Commons to Queen Anne, expressing their support for the impeachment of the radical preacher Dr Henry Sacheverell (see Burke, 2003). Three years later in 1713, as a note on the back flyleaf (<a href='' onclick='store.loadPage(176);return false;'>p. 174<\/a>) indicates, Lyttelton passed the manuscript on to her cousin Edward Tenison. He does not appear to have added to it. The majority of the items were probably entered in the 1670s and 1680s, but a more precise terminus a quo cannot be established, since some of the items were composed considerably earlier. Lyttelton seems to have added her second batch of entries after 1687, since this batch includes four poems by John Norris not published until that year."
+		},
+		{
+			"label": "Decoration",
+			"value": "<p>None, except the Latin motto (perhaps that of Sir Walter Ralegh) on <a href='' onclick='store.loadPage(74);return false;'>p. 72<\/a>, 'AMORE ET VERTVTE', which is written inside a hand-drawn banner.<\/p>"
+		},
+		{
+			"label": "Subject(s)",
+			"value": "Verse; Prose; Devotional; Sermons; Women's Writing; Book Lists; Church History; Classics; Commonplaces"
+		},
+		{
+			"label": "Language(s)",
+			"value": "Mostly English, but some French and occasional Latin"
+		},
+		{
+			"label": "Layout",
+			"value": "<p>No ruling or pricking.<\/p> <p>Texts entered in one column, with a variable number of lines per page.<\/p> <p>No quire or leaf signatures.<\/p> <p>No catchwords.<\/p>"
+		},
+		{
+			"label": "Foliation",
+			"value": "<p> <p>Modern pagination added, accurately and consecutively (1-174), in pencil to top of outer margin; one unpaginated stub between <a href='' onclick='store.loadPage(6);return false;'>pp. 4-5<\/a>.<\/p> <p>Items entered at both ends of the manuscript by first two owners, so that the terms 'beginning' and 'end' are arbitrary ones, and apply only to this pencilled pagination (see Keynes, <i>Commonplace Book<\/i>, p. 9). The first owner of the book, Lady Dorothy Browne, copied entries at what are now <a href='' onclick='store.loadPage(173);return false;'>pp. 171-104<\/a> and <a href='' onclick='store.loadPage(104);return false;'>p. 102<\/a>, whilst the second owner, her daughter Elizabeth Lyttelton, wrote entries at both ends of the book (<a href='' onclick='store.loadPage(4);return false;'>pp. 2-45<\/a>, <a href='' onclick='store.loadPage(176);return false;'>pp. 174-171<\/a>, and <a href='' onclick='store.loadPage(105);return false;'>pp. 103-46<\/a>).<\/p> <p>Our digital facsimile follows this pagination in order to preserve the integrity of the manuscript. However, after the first 45 pages, we have reversed the manuscript and also the images of the individual pages (<a href='' onclick='store.loadPage(48);return false;'>pp. 46-174<\/a>) to facilitate consultation and reading. Thus our user will open the manuscript from one end, but read it from both ends. We believe that this decision allows us to replicate both how the original owners used the manuscript and the experience of a modern reader faced with it in the Manuscripts Reading Room of Cambridge University Library. We have, in effect, sought to replicate digitally the process of turning the manuscript physically, which any reader of it would need to do.<\/p> <\/p>"
+		},
+		{
+			"label": "Bibliography",
+			"value": "<div style='list-style-type: disc;'><div style='display: list-item; margin-left: 20px;' id=\"ANON1964\"><i>Bibliotheca Bibliographici: A Catalogue of the Library Formed by Geoffrey Keynes<\/i> (London: Trianon Press, 1964) number. 1301.<\/div><div style='display: list-item; margin-left: 20px;' id=\"BURKE2003\">Burke, Victoria, \"Contexts for Women's Manuscript Miscellanies: The Case of Elizabeth Lyttelton and Sir Thomas Browne\", in <i>The Yearbook of English Studies<\/i> (2003) vol. 33 pages. 316-28.<\/div><div style='display: list-item; margin-left: 20px;' id=\"DOBELL1918\">Dobell, Percy John, <i>The Literature of the Restoration, Being a Collection of the Poetical and Dramatic Literature Produced between the Years 1660 and 1700, with Particular Reference to the Writings of John Dryden<\/i> (London: P. J. & J. E. Dobell, 1918) pages. 95.<\/div><div style='display: list-item; margin-left: 20px;' id=\"EVANS1979\">Evans, John T., <i>Seventeenth-Century Norwich: Politics, Religion and Government, 1620-1690<\/i> (Oxford: Clarendon Press, 1979).<\/div><div style='display: list-item; margin-left: 20px;' id=\"KEYNES1919\">Keynes, Geoffrey, <i>The Commonplace Book of Elizabeth Lyttelton<\/i> (Cambridge: Cambridge University Press, 1919).<\/div><div style='display: list-item; margin-left: 20px;' id=\"KEYNESTLS1919\">Keynes, Geoffrey, \"A Daughter of Sir Thomas Browne\", in <i>The Times Literary Supplement<\/i> (1919) vol. 922 pages. 470.<\/div><div style='display: list-item; margin-left: 20px;' id=\"MORAN1952\">Moran, Berna, \"Sir Thomas Browne's Reading on the Turks\", in <i>Notes & Queries<\/i> (1952) vol. 197 pages. 380-82, 403-6.<\/div><div style='display: list-item; margin-left: 20px;' id=\"MORRIS1986\">Morris, G. C. R., \"Sir Thomas Browne's Daughters, 'Cosen Barker', and the Cottrells\", in <i>Notes & Queries<\/i> (1986) vol. 231 pages. 472-78.<\/div><div style='display: list-item; margin-left: 20px;' id=\"NELSON2008\">Nelson, Brent, \"The Browne Family's Culture of Curiosity\", in Barbour, Reid, and Claire Preston, eds , <i>The World Proposed: Essays on Thomas Browne<\/i> (Oxford: Oxford University Press, 2008) pages. 80-99.<\/div><\/div><br />"
+		}
+	],
+	"@type": "sc:Manifest",
+	"attribution": "Provided by Cambridge University Library. Zooming image © Cambridge University Library, all rights reserved  The images of this manuscript are published under a Creative Commons Attribution-NonCommercial-NoDeriv license. You are free to copy, distribute and transmit this image, under the following conditions: Attribution. You must attribute the image, in all cases, to Cambridge University Library, and to Scriptorium: Medieval and Early Modern Manuscripts Online. Non-commercial. You may not use this image for any commercial purposes. No Derivative Works. You may not alter, transform, or build upon this image. Any requests for a higher-definition copy of this image, or permission to publish, should be directed to the Imaging Services Department, Cambridge University Library. For further information, you should consult the University Library website at http://www.lib.cam.ac.uk/deptserv/imagingservices/reproductionrights.html.  This metadata is licensed under a Creative Commons Attribution-NonCommercial 3.0 Unported License.",
+	"structures": [
+		{
+			"ranges": [
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-1",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-2",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-3",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-4",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-5",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-6",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-7",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-8",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-9",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-10",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-11",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-12",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-13",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-14",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-15",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-16",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-17",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-18",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-19",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-20",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-21",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-22",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-23",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-24",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-25",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-26",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-27",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-28",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-29",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-30",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-31",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-32",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-33",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-34",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-35",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-36",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-37",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-38",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-39",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-40",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-41",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-42",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-43",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-44",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-45",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-46",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-47",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-48",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-49",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-50",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-51",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-52",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-53",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-54",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-55",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-56",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-57",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-58",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-59",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-60",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-61",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-62",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-63",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-64",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-65",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-66",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-67",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-68",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-69",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-70",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-71",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-72",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-73",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-74",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-75",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-76",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-77",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-78",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-79",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-80",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-81",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-82",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-83",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-84",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-85",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-86",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-87",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-88",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-89",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-90",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-91",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-92",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-93",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-94",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-95",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-96",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-97"
+			],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/DOCUMENT",
+			"label": "Elizabeth Lyttelton's commonplace book; English, French, and Latin; 1670s-1713."
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/4"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-1",
+			"label": "whateuer Praises are or haue been due"
+		},
+		{
+			"canvases": [
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/5",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/6",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/7",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/8"
+			],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-2",
+			"label": "A Hymne to our Creator by D<sup>r<\/sup> Dillingham"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/7"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-3",
+			"label": "In ev'ry Action, whatsoe're it is"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/7"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-4",
+			"label": "be Constant be Constant Feare not for Pain"
+		},
+		{
+			"canvases": [
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/8",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/9",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/10",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/11",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/12",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/13",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/14",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/15",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/16",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/17",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/18",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/19",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/20",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/21"
+			],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-5",
+			"label": "An hymne to our Redeemer"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/9"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-6",
+			"label": "We're all deluded, vainely Searching wayes,"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/10"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-7",
+			"label": "upon the remoue of the body of Queen Elizabeth <br /> from Richmond where she dyed the 24 of March, 1602 the 45<br /> year of her Raign, & seventy of her age,"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/10"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-8",
+			"label": "she was & is, what Can there more be said"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/10"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-9",
+			"label": "Spains rod, Romes ruin, Netherlands reliefe:"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/11"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-10",
+			"label": "Vnto the wiser Gods the care permit,"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/11"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-11",
+			"label": "Inconstancy"
+		},
+		{
+			"canvases": [
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/12",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/13",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/14",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/15",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/16"
+			],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-12",
+			"label": "Beauty"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/13"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-13",
+			"label": "Peccatum Redivivum: Or, The Rebellion of a Conquer'd Lust"
+		},
+		{
+			"canvases": [
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/15",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/16",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/17",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/18",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/19"
+			],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-14",
+			"label": "When our Emmanuell from his Throne came down"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/16"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-15",
+			"label": "Love"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/19"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-16",
+			"label": "On the words hoc est corpus meum"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/19"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-17",
+			"label": "by Divine rapturs wee aspire"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/21"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-18",
+			"label": "From age and death only the Gods are free"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/21"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-19",
+			"label": "Whom they for euer haue, with Loue yet higher"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/23"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-20",
+			"label": "An Euening Hymn,"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/24"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-21",
+			"label": "Plato's two Cupids"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/25"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-22",
+			"label": "sen. Res severa et verum gaudium ."
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/26"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-23",
+			"label": "The Refinement"
+		},
+		{
+			"canvases": [
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/27",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/28",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/29",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/30"
+			],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-24",
+			"label": "Some Essays of Morality in prozaick Ryme<br /> upon Aristotles definition of friendly Loue"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/30"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-25",
+			"label": "s<sup>t<\/sup> Aug. climarum"
+		},
+		{
+			"canvases": [
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/31",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/32",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/33",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/34"
+			],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-26",
+			"label": "an Essay of Morall fortetude according to Aristotle"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/34"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-27",
+			"label": "N'apprehende<i class='delim' style='font-style:normal; color:red'>〚<\/i><i class='del' style='font-style:normal; text-decoration:line-through;' title='This text deleted'>r<\/i><i class='delim' style='font-style:normal; color:red'>〛<\/i> pas que Je Change"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/35"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-28",
+			"label": "On Dr. Brown's Travels"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/36"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-29",
+			"label": "October y<sup>e<\/sup> 16 1555, was burned at Oxford y<sup>e<\/sup> Blessed Martyrs in"
+		},
+		{
+			"canvases": [
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/37",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/38",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/39",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/40",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/41",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/42"
+			],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-30",
+			"label": "Wandring & Languid is the life he spends"
+		},
+		{
+			"canvases": [
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/43",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/44"
+			],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-31",
+			"label": "Already, Already I hear you, make your wonted replies he that"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/44"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-32",
+			"label": "Know I what years heaven has for mee decreed"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/44"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-33",
+			"label": "If advers fortune bring to Pass"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/45"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-34",
+			"label": "Of Consumptions"
+		},
+		{
+			"canvases": [
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/46",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/47"
+			],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-35",
+			"label": "The books which my daughter Elizabeth hath<br /> read unto me at nights till she read y<sup>m<\/sup> all out"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/176"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-36",
+			"label": "2 for 1 3 for 5 then 2 & then 2 & 4 Comes by line"
+		},
+		{
+			"canvases": [],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-37",
+			"label": "S<sup>r<\/sup> Walter Rawleigs Letter to his wife after his<br /> Condemnation"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/173"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-38",
+			"label": "The Eloquence of inferiours is in words"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/173"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-39",
+			"label": "the 7 Penitentiall <i class='delim' style='font-style:normal; color:red'>〚<\/i><i class='del' style='font-style:normal; text-decoration:line-through;' title='This text deleted'>spa<\/i><i class='delim' style='font-style:normal; color:red'>〛<\/i> psalms, the 6, 39, 37, 50,"
+		},
+		{
+			"canvases": [
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/161",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/162",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/163",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/164",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/165",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/166",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/167",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/168",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/169",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/170",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/171",
+				"https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/172"
+			],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-40",
+			"label": "M<sup>r<\/sup> Bottman"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/172"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-41",
+			"label": "M<sup>r<\/sup> Botman Re: 2: 9"
+		},
+		{
+			"canvases": [],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-42",
+			"label": "short notes of M<sup>r<\/sup> Phillips his sermons in<br /> Romanes 1. 3. 4"
+		},
+		{
+			"canvases": [],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-43",
+			"label": "But put yee on the Lord Iesus Christ and make not"
+		},
+		{
+			"canvases": [],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-44",
+			"label": "Short notes of M<sup>r<\/sup> Holliburton his<br /> sermon on Chr. day"
+		},
+		{
+			"canvases": [],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-45",
+			"label": "Short nots of a uery good sarmon<br /> on: 1: Pee. 4. 12: 13"
+		},
+		{
+			"canvases": [],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-46",
+			"label": "Sermon notes"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/105"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-47",
+			"label": "Sacred to the Memory of the Lady Dorothy Brown of Norwich, she dyed Feb. 24. 1685 <br /> in the sixty third year of her age"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/104"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-48",
+			"label": "St Andrew when he saw y<sup>e<\/sup> Cross, O Cross most welcome"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/103"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-49",
+			"label": "Le printemps quelques foys est moins doux quil me semble"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/103"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-50",
+			"label": "autre"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/102"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-51",
+			"label": "M<sup>r<\/sup> Hierome Said again unto them: you will con-"
+		},
+		{
+			"canvases": [],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-52",
+			"label": "The Prayer of Luther at his death"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/98"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-53",
+			"label": "The usuall Prayer of Docter Martyn Luther"
+		},
+		{
+			"canvases": [],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-54",
+			"label": "Upon a Tempest at Sea"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/94"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-55",
+			"label": "Some Arabian Proverbs"
+		},
+		{
+			"canvases": [],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-56",
+			"label": "Italian & French Proverbs rythmisd"
+		},
+		{
+			"canvases": [],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-57",
+			"label": "The Character of a Happy Life"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/85"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-58",
+			"label": "My Loue is Crucified"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/84"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-59",
+			"label": "Upon the Sudden Restraint of the Earl of Somerset then falling from favour"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/83"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-60",
+			"label": "Elizabeth Lyttelton"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/82"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-61",
+			"label": "An Epitaph upon Queen Elizabeth"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/81"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-62",
+			"label": "King James came in progres to the house of S<sup>r<\/sup> <br /> Pope Knight, when his Lady was lately delivered<br /> of a daughter, which babe was Presented to the<br /> King with a Paper of verses in her hand,<br /> <i class='delim' style='font-style:normal; color:red'>〚<\/i><i class='del' style='font-style:normal; text-decoration:line-through;' title='This text deleted'>which because<\/i><i class='delim' style='font-style:normal; color:red'>〛<\/i>"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/80"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-63",
+			"label": "A Turkish Prayer or Alhemdolilla"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/79"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-64",
+			"label": "Seignor verdero in his proper habitt,"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/79"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-65",
+			"label": "An Epitaph upon Felton, who was hang'd in Chains for murdering the Old Duke of Buckingham"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/78"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-66",
+			"label": "Fragment on meadows"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/77"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-67",
+			"label": "To Mr. W. B. at the Birth of his first Child"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/76"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-68",
+			"label": "He Talkt, he wrote, he Thought nought else but LOVES:"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/75"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-69",
+			"label": "out of my Ld Cheif Justice Scrog speech"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/74"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-70",
+			"label": "the Almond florisheth y<sup>e<\/sup> Birch trees flowe"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/74"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-71",
+			"label": "Untitled Item"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/73"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-72",
+			"label": "The humble Addres of y<sup>e<\/sup> house of Commons to the Queen, March y<sup>e<\/sup> 7 1710"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/72"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-73",
+			"label": "A Virgin"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/71"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-74",
+			"label": "A Happy Life out of Martial"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/71"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-75",
+			"label": "They swell with loue that are with valour fild"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/70"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-76",
+			"label": "D<sup>r<\/sup> Alabasters verses upon D<sup>r<\/sup> Reynolds & his Brother"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/70"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-77",
+			"label": "And (world mourn'd) Sidney, warbling to the Thames"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/70"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-78",
+			"label": "Sidney thy works in fames book are inrooll'd"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/69"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-79",
+			"label": "To the King"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/68"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-80",
+			"label": "A treacherous Fryer who dyed the other day"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/68"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-81",
+			"label": "There for a token I did thinke it meete"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/67"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-82",
+			"label": "on his Mistress going to Sea"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/66"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-83",
+			"label": "The Gods haue Vertue set upon a Lofty hill,"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/66"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-84",
+			"label": "one sorrow by an other is revived"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/65"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-85",
+			"label": "The Epitaph upon that Blessed Martyr Walter Mill <br /> at St Andrews in Scotland"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/64"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-86",
+			"label": "A Hymne to God the Father"
+		},
+		{
+			"canvases": [],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-87",
+			"label": "A Christian paraphrase on those Verses<br /> Like Hermit poor, &c,"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/62"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-88",
+			"label": "here Vertue, Valour, Charity, and all"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/62"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-89",
+			"label": "on Doctor Hewyt"
+		},
+		{
+			"canvases": [],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-90",
+			"label": "Psalme 56. v. 3.<br /> What time I am affraid I will trust in thee."
+		},
+		{
+			"canvases": [],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-91",
+			"label": "On the Death of Sr Albertus Morton"
+		},
+		{
+			"canvases": [],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-92",
+			"label": "An Elegie upon the Death of his own Father"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/52"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-93",
+			"label": "To his Son Vincent Corbett"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/51"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-94",
+			"label": "Even such is time which takes in trust"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/51"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-95",
+			"label": "On Sir Walter Rawleygh"
+		},
+		{
+			"canvases": ["https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/50"],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-96",
+			"label": "Epitaph on William Fairfax"
+		},
+		{
+			"canvases": [],
+			"@type": "sc:Range",
+			"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/range/ITEM-97",
+			"label": "King James his Epitaph by Bishop Corbet"
+		}
+	],
+	"description": "",
+	"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640",
+	"label": "Elizabeth Lyttelton's commonplace book; English, French, and Latin; 1670s-1713. (UL MS Add. 8460)",
+	"sequences": [{
+		"canvases": [
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00001.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00001.jp2",
+						"height": 6256
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/1"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/1",
+				"label": "front_cover",
+				"height": 6256
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00002.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00002.jp2",
+						"height": 6128
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/2"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/2",
+				"label": "inside_front_cover",
+				"height": 6128
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00003.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00003.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/3"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/3",
+				"label": "1",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00004.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00004.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/4"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/4",
+				"label": "2",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00005.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00005.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/5"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/5",
+				"label": "3",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00006.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00006.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/6"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/6",
+				"label": "4",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00007.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00007.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/7"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/7",
+				"label": "5",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00008.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00008.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/8"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/8",
+				"label": "6",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00009.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00009.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/9"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/9",
+				"label": "7",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00010.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00010.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/10"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/10",
+				"label": "8",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00011.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00011.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/11"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/11",
+				"label": "9",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00012.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00012.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/12"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/12",
+				"label": "10",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00013.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00013.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/13"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/13",
+				"label": "11",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00014.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00014.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/14"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/14",
+				"label": "12",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00015.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00015.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/15"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/15",
+				"label": "13",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00016.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00016.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/16"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/16",
+				"label": "14",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00017.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00017.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/17"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/17",
+				"label": "15",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00018.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00018.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/18"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/18",
+				"label": "16",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00019.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00019.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/19"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/19",
+				"label": "17",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00020.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00020.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/20"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/20",
+				"label": "18",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00021.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00021.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/21"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/21",
+				"label": "19",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00022.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00022.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/22"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/22",
+				"label": "20",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00023.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00023.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/23"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/23",
+				"label": "21",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00024.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00024.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/24"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/24",
+				"label": "22",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00025.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00025.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/25"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/25",
+				"label": "23",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00026.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00026.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/26"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/26",
+				"label": "24",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00027.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00027.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/27"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/27",
+				"label": "25",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00028.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00028.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/28"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/28",
+				"label": "26",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00029.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00029.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/29"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/29",
+				"label": "27",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00030.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00030.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/30"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/30",
+				"label": "28",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00031.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00031.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/31"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/31",
+				"label": "29",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00032.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00032.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/32"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/32",
+				"label": "30",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00033.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00033.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/33"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/33",
+				"label": "31",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00034.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00034.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/34"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/34",
+				"label": "32",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00035.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00035.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/35"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/35",
+				"label": "33",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00036.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00036.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/36"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/36",
+				"label": "34",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00037.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00037.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/37"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/37",
+				"label": "35",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00038.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00038.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/38"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/38",
+				"label": "36",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00039.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00039.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/39"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/39",
+				"label": "37",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00040.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00040.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/40"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/40",
+				"label": "38",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00041.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00041.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/41"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/41",
+				"label": "39",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00042.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00042.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/42"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/42",
+				"label": "40",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00043.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00043.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/43"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/43",
+				"label": "41",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00044.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00044.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/44"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/44",
+				"label": "42",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00045.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00045.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/45"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/45",
+				"label": "43",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00046.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00046.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/46"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/46",
+				"label": "44",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00047.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00047.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/47"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/47",
+				"label": "45",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00048.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00048.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/48"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/48",
+				"label": "46",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00049.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00049.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/49"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/49",
+				"label": "47",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00050.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00050.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/50"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/50",
+				"label": "48",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00051.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00051.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/51"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/51",
+				"label": "49",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00052.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00052.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/52"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/52",
+				"label": "50",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00053.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00053.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/53"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/53",
+				"label": "51",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00054.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00054.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/54"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/54",
+				"label": "52",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00055.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00055.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/55"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/55",
+				"label": "53",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00056.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00056.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/56"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/56",
+				"label": "54",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00057.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00057.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/57"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/57",
+				"label": "55",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00058.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00058.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/58"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/58",
+				"label": "56",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00059.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00059.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/59"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/59",
+				"label": "57",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00060.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00060.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/60"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/60",
+				"label": "58",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00061.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00061.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/61"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/61",
+				"label": "59",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00062.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00062.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/62"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/62",
+				"label": "60",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00063.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00063.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/63"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/63",
+				"label": "61",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00064.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00064.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/64"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/64",
+				"label": "62",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00065.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00065.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/65"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/65",
+				"label": "63",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00066.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00066.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/66"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/66",
+				"label": "64",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00067.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00067.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/67"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/67",
+				"label": "65",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00068.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00068.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/68"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/68",
+				"label": "66",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00069.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00069.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/69"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/69",
+				"label": "67",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00070.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00070.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/70"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/70",
+				"label": "68",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00071.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00071.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/71"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/71",
+				"label": "69",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00072.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00072.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/72"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/72",
+				"label": "70",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00073.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00073.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/73"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/73",
+				"label": "71",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00074.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00074.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/74"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/74",
+				"label": "72",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00075.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00075.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/75"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/75",
+				"label": "73",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00076.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00076.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/76"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/76",
+				"label": "74",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00077.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00077.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/77"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/77",
+				"label": "75",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00078.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00078.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/78"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/78",
+				"label": "76",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00079.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00079.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/79"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/79",
+				"label": "77",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00080.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00080.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/80"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/80",
+				"label": "78",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00081.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00081.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/81"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/81",
+				"label": "79",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00082.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00082.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/82"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/82",
+				"label": "80",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00083.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00083.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/83"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/83",
+				"label": "81",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00084.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00084.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/84"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/84",
+				"label": "82",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00085.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00085.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/85"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/85",
+				"label": "83",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00086.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00086.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/86"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/86",
+				"label": "84",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00087.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00087.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/87"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/87",
+				"label": "85",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00088.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00088.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/88"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/88",
+				"label": "86",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00089.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00089.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/89"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/89",
+				"label": "87",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00090.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00090.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/90"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/90",
+				"label": "88",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00091.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00091.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/91"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/91",
+				"label": "89",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00092.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00092.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/92"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/92",
+				"label": "90",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00093.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00093.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/93"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/93",
+				"label": "91",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00094.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00094.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/94"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/94",
+				"label": "92",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00095.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00095.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/95"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/95",
+				"label": "93",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00096.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00096.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/96"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/96",
+				"label": "94",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00097.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00097.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/97"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/97",
+				"label": "95",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00098.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00098.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/98"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/98",
+				"label": "96",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00099.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00099.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/99"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/99",
+				"label": "97",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00100.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00100.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/100"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/100",
+				"label": "98",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00101.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00101.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/101"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/101",
+				"label": "99",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00102.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00102.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/102"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/102",
+				"label": "100",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00103.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00103.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/103"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/103",
+				"label": "101",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00104.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00104.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/104"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/104",
+				"label": "102",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00105.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00105.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/105"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/105",
+				"label": "103",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00106.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00106.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/106"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/106",
+				"label": "104",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00107.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00107.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/107"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/107",
+				"label": "105",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00108.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00108.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/108"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/108",
+				"label": "106",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00109.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00109.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/109"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/109",
+				"label": "107",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00110.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00110.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/110"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/110",
+				"label": "108",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00111.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00111.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/111"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/111",
+				"label": "109",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00112.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00112.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/112"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/112",
+				"label": "110",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00113.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00113.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/113"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/113",
+				"label": "111",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00114.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00114.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/114"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/114",
+				"label": "112",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00115.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00115.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/115"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/115",
+				"label": "113",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00116.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00116.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/116"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/116",
+				"label": "114",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00117.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00117.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/117"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/117",
+				"label": "115",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00118.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00118.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/118"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/118",
+				"label": "116",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00119.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00119.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/119"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/119",
+				"label": "117",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00120.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00120.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/120"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/120",
+				"label": "118",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00121.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00121.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/121"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/121",
+				"label": "119",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00122.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00122.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/122"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/122",
+				"label": "120",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00123.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00123.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/123"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/123",
+				"label": "121",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00124.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00124.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/124"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/124",
+				"label": "122",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00125.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00125.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/125"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/125",
+				"label": "123",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00126.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00126.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/126"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/126",
+				"label": "124",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00127.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00127.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/127"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/127",
+				"label": "125",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00128.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00128.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/128"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/128",
+				"label": "126",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00129.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00129.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/129"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/129",
+				"label": "127",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00130.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00130.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/130"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/130",
+				"label": "128",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00131.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00131.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/131"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/131",
+				"label": "129",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00132.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00132.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/132"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/132",
+				"label": "130",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00133.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00133.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/133"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/133",
+				"label": "131",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00134.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00134.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/134"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/134",
+				"label": "132",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00135.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00135.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/135"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/135",
+				"label": "133",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00136.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00136.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/136"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/136",
+				"label": "134",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00137.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00137.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/137"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/137",
+				"label": "135",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00138.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00138.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/138"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/138",
+				"label": "136",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00139.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00139.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/139"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/139",
+				"label": "137",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00140.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00140.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/140"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/140",
+				"label": "138",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00141.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00141.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/141"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/141",
+				"label": "139",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00142.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00142.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/142"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/142",
+				"label": "140",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00143.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00143.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/143"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/143",
+				"label": "141",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00144.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00144.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/144"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/144",
+				"label": "142",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00145.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00145.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/145"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/145",
+				"label": "143",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00146.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00146.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/146"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/146",
+				"label": "144",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00147.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00147.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/147"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/147",
+				"label": "145",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00148.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00148.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/148"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/148",
+				"label": "146",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00149.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00149.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/149"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/149",
+				"label": "147",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00150.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00150.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/150"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/150",
+				"label": "148",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00151.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00151.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/151"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/151",
+				"label": "149",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00152.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00152.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/152"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/152",
+				"label": "150",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00153.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00153.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/153"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/153",
+				"label": "151",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00154.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00154.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/154"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/154",
+				"label": "152",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00155.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00155.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/155"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/155",
+				"label": "153",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00156.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00156.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/156"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/156",
+				"label": "154",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00157.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00157.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/157"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/157",
+				"label": "155",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00158.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00158.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/158"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/158",
+				"label": "156",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00159.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00159.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/159"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/159",
+				"label": "157",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00160.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00160.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/160"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/160",
+				"label": "158",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00161.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00161.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/161"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/161",
+				"label": "170",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00162.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00162.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/162"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/162",
+				"label": "169",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00163.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00163.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/163"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/163",
+				"label": "168",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00164.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00164.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/164"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/164",
+				"label": "167",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00165.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00165.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/165"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/165",
+				"label": "166",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00166.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00166.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/166"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/166",
+				"label": "165",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00167.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00167.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/167"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/167",
+				"label": "164",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00168.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00168.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/168"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/168",
+				"label": "163",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00169.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00169.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/169"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/169",
+				"label": "162",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00170.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00170.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/170"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/170",
+				"label": "161",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00171.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00171.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/171"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/171",
+				"label": "160",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00172.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00172.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/172"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/172",
+				"label": "159",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00173.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00173.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/173"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/173",
+				"label": "171",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00174.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00174.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/174"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/174",
+				"label": "172",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00175.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00175.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/175"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/175",
+				"label": "173",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00176.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00176.jp2",
+						"height": 7230
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/176"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/176",
+				"label": "174",
+				"height": 7230
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00177.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00177.jp2",
+						"height": 6112
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/177"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/177",
+				"label": "inside_back_cover",
+				"height": 6112
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00178.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 5428,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00178.jp2",
+						"height": 6112
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/178"
+				}],
+				"@type": "sc:Canvas",
+				"width": 5428,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/178",
+				"label": "back_cover",
+				"height": 6112
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00179.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 7223,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00179.jp2",
+						"height": 4102
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/179"
+				}],
+				"@type": "sc:Canvas",
+				"width": 7223,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/179",
+				"label": "spine",
+				"height": 4102
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00180.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 7230,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00180.jp2",
+						"height": 4766
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/180"
+				}],
+				"@type": "sc:Canvas",
+				"width": 7230,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/180",
+				"label": "bottom_edge",
+				"height": 4766
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00181.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 7230,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00181.jp2",
+						"height": 3686
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/181"
+				}],
+				"@type": "sc:Canvas",
+				"width": 7230,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/181",
+				"label": "long_edge",
+				"height": 3686
+			},
+			{
+				"images": [{
+					"resource": {
+						"@type": "dctypes:Image",
+						"service": {
+							"profile": "http://iiif.io/api/image/2/level1.json",
+							"@id": "//localhost:8081/info/MS-ADD-08640-000-00182.jp2",
+							"@context": "http://iiif.io/api/image/2/context.json"
+						},
+						"format": "image/jpg",
+						"width": 7230,
+						"@id": "//localhost:8081/info/MS-ADD-08640-000-00182.jp2",
+						"height": 4742
+					},
+					"@type": "oa:Annotation",
+					"motivation": "sc:painting",
+					"on": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/182"
+				}],
+				"@type": "sc:Canvas",
+				"width": 7230,
+				"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/canvas/182",
+				"label": "top_edge",
+				"height": 4742
+			}
+		],
+		"@type": "sc:Sequence",
+		"@id": "https://cudl.lib.cam.ac.uk/iiif/MS-ADD-08640/sequence",
+		"label": "Current Page Order"
+	}],
+	"@context": "http://iiif.io/api/presentation/2/context.json",
+	"seeAlso": "https://services.cudl.lib.cam.ac.uk/v1/metadata/tei/MS-ADD-08640/"
+}


### PR DESCRIPTION
If the manifest contains ranges without canvases, thumbnails and the TOC were not displayed at all. Those ranges are now ignored and both panels are working again.

Resolves #32.