### PR TITLE
Version in dist filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The required HTML code looks something like this:
 
 ``` html
 <div id="tify"></div>
-<script src="tify.js"></script>
+<script src="tify-0.24.2.js"></script>
 ```
 
 The only required parameter `manifest` is a URL pointing to the manifest. It can be set either as a query parameter or with the `tifyOptions` object, whereby the latter takes precedence.
@@ -60,7 +60,7 @@ Below an example with all available options set.
 		title: null,
 	}
 </script>
-<script src="tify.js"></script>
+<script src="tify-0.24.2.js"></script>
 ```
 
 ## Build Setup

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,5 @@
+# Upgrading TIFY
+
+## From any release to `main` (unreleased)
+
+- The dist files now include the current version of TIFY. Change `<script src="tify.js"></script>` to  `<script src="tify-0.24.2.js"></script>`. Should you use a custom URL for the default stylesheet, add the version there as well.

--- a/demo.html
+++ b/demo.html
@@ -58,5 +58,5 @@
 		</span>
 	</h1>
 	<div id="tify"></div>
-	<script src="dist/tify.js"></script>
+	<script src="dist/tify-0.24.2.js"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -64,7 +64,7 @@ if (process.env.NODE_ENV === 'production') {
 	const scripts = document.getElementsByTagName('script');
 	const scriptUrl = scripts[scripts.length - 1];
 	base = scriptUrl.src.substring(0, scriptUrl.src.lastIndexOf('/'));
-	stylesheetUrl = `${base}/tify.css`;
+	stylesheetUrl = `${base}/tify-${process.env.VUE_APP_VERSION}.css`;
 } else {
 	base = '';
 	stylesheetUrl = null;

--- a/src/views/Help.vue
+++ b/src/views/Help.vue
@@ -9,21 +9,21 @@
 				released under the GNU Affero General Public License 3.0.
 			</p>
 			<p>
-				Version {{ info.VERSION }}
+				Version {{ env.VUE_APP_VERSION }}
 			</p>
 			<ul>
 				<li>
-					<a :href="info.DOCS_URL">Documentation</a>
+					<a :href="env.VUE_APP_DOCS_URL">Documentation</a>
 				</li>
 				<li>
-					<a :href="info.REPOSITORY_URL">Source code</a>
+					<a :href="env.VUE_APP_REPOSITORY_URL">Source code</a>
 				</li>
 				<li>
-					<a :href="info.CONTRIBUTORS_URL">Contributors</a>
+					<a :href="env.VUE_APP_CONTRIBUTORS_URL">Contributors</a>
 				</li>
 			</ul>
 			<p>
-				<a :href="info.BUGS_URL">Report a bug</a>
+				<a :href="env.VUE_APP_BUGS_URL">Report a bug</a>
 			</p>
 			<p>
 				Copyright &copy; 2017&ndash;2020
@@ -38,8 +38,8 @@
 <script>
 export default {
 	computed: {
-		info() {
-			return JSON.parse(unescape(process.env.VUE_APP_INFO));
+		env() {
+			return process.env;
 		},
 	},
 };

--- a/vue.config.js
+++ b/vue.config.js
@@ -11,17 +11,17 @@ process.env.VUE_APP_DOCS_URL = `${env.repository.url}/blob/v${env.version}/doc`;
 process.env.VUE_APP_REPOSITORY_URL = env.repository.url;
 
 module.exports = {
-	chainWebpack: config => {
+	chainWebpack: (config) => {
 		config.module.rule('eslint')
 			.use('eslint-loader')
-			.options({ fix: true })
+			.options({ fix: true });
 	},
 	configureWebpack: {
 		optimization: {
 			splitChunks: false,
 		},
 		output: {
-			filename: '[name].js',
+			filename: `[name]-${env.version}.js`,
 		},
 		plugins: [
 			// Prepend copyright notice to each compiled file
@@ -36,7 +36,7 @@ module.exports = {
 	},
 	css: {
 		extract: {
-			filename: '[name].css',
+			filename: `[name]-${env.version}.css`,
 		},
 		loaderOptions: {
 			scss: {

--- a/vue.config.js
+++ b/vue.config.js
@@ -3,16 +3,12 @@ const globImporter = require('node-sass-glob-importer');
 
 const env = require('./package.json');
 
-const info = {
-	VERSION: env.version,
-	LICENSE: env.license,
-	BUGS_URL: env.bugs.url,
-	CONTRIBUTORS_URL: 'https://github.com/tify-iiif-viewer/tify/blob/main/CONTRIBUTORS.md',
-	DOCS_URL: `${env.repository.url}/blob/v${env.version}/doc`,
-	REPOSITORY_URL: env.repository.url,
-};
-
-process.env.VUE_APP_INFO = escape(JSON.stringify(info));
+process.env.VUE_APP_VERSION = env.version;
+process.env.VUE_APP_LICENSE = env.license;
+process.env.VUE_APP_BUGS_URL = env.bugs.url;
+process.env.VUE_APP_CONTRIBUTORS_URL = 'https://github.com/tify-iiif-viewer/tify/blob/main/CONTRIBUTORS.md';
+process.env.VUE_APP_DOCS_URL = `${env.repository.url}/blob/v${env.version}/doc`;
+process.env.VUE_APP_REPOSITORY_URL = env.repository.url;
 
 module.exports = {
 	chainWebpack: config => {


### PR DESCRIPTION
To avoid confusion and to prevent caching issues, dist filenames now include the current TIFY version.

The commits of this pull request should not be squashed.

Any ideas on how to automatically update the version in `README.md` and `demo.html`?