### PR TITLE
Improve handling of long metadata items

### DIFF
--- a/src/components/MetadataList.vue
+++ b/src/components/MetadataList.vue
@@ -2,7 +2,7 @@
 	<div class="tify-info_metadata">
 		<div v-for="(item, index) in metadata" :key="index">
 			<h4>
-				<div v-bind:key="index" v-for="(label, index) in getLabels(item.label)">
+				<div v-bind:key="index" v-for="(label, index) in $root.convertValueToArray(item.label)">
 					{{ label|cleanLabel }}
 				</div>
 			</h4>
@@ -12,7 +12,7 @@
 				ref="contents"
 			>
 				<div class="tify-info_value">
-					<div v-bind:key="value" v-for="value in getLabels(item.value)" v-html="value"/>
+					<div v-bind:key="value" v-for="value in $root.convertValueToArray(item.value)" v-html="value"/>
 				</div>
 
 				<button
@@ -46,7 +46,7 @@ export default {
 	},
 	watch: {
 		metadata() {
-			this.$nextTick(() => this.updateInfoItems());
+			this.updateInfoItems();
 		},
 	},
 	filters: {
@@ -60,31 +60,30 @@ export default {
 	},
 	methods: {
 		updateInfoItems() {
-			this.$refs.contents.forEach((content, index) => {
-				const fullHeight = content.offsetHeight;
+			this.$nextTick(() => {
+				if (!this.$refs.contents) {
+					return;
+				}
 
-				this.$set(this.infoItems, index, {
-					collapsed: true,
-					exceedsHeight: true,
-				});
-
-				this.$nextTick(() => {
-					const collapsedHeight = content.offsetHeight;
-					const shouldBeCollapsed = fullHeight >= collapsedHeight;
+				this.$refs.contents.forEach((content, index) => {
+					const fullHeight = content.offsetHeight;
 
 					this.$set(this.infoItems, index, {
-						collapsed: shouldBeCollapsed,
-						exceedsHeight: shouldBeCollapsed,
+						collapsed: true,
+						exceedsHeight: true,
+					});
+
+					this.$nextTick(() => {
+						const collapsedHeight = content.offsetHeight;
+						const shouldBeCollapsed = fullHeight >= collapsedHeight;
+
+						this.$set(this.infoItems, index, {
+							collapsed: shouldBeCollapsed,
+							exceedsHeight: shouldBeCollapsed,
+						});
 					});
 				});
 			});
-		},
-		stripHtml(html) {
-			const doc = new DOMParser().parseFromString(html, 'text/html');
-			return doc.body.textContent || '';
-		},
-		getLabels(value) {
-			return this.$root.convertValueToArray(value);
 		},
 	},
 };

--- a/src/components/MetadataList.vue
+++ b/src/components/MetadataList.vue
@@ -1,58 +1,52 @@
 <template>
 	<div class="tify-info_metadata">
 		<div v-for="(item, index) in metadata" :key="index">
-			<template>
-				<h4>
-					<div v-bind:key="index" v-for="(label, index) in getLabels(item.label)">
-						{{ label|cleanLabel }}
-					</div>
-				</h4>
-				<div class="tify-info_content">
-					<div
-						class="tify-info_value"
-						:class="{ '-collapsed': infoItems && infoItems[index] && infoItems[index].isCollapsed }"
-						:style="infoItems && infoItems[index] && infoItems[index].isCollapsed ? collapsedStyle : null"
-					>
-						<div v-bind:key="value" v-for="value in getLabels(item.value)" v-html="value"/>
-					</div>
-
-					<button
-						v-if="!infoItems || (infoItems && infoItems[index] && infoItems[index].isInitiallyCollapsed)"
-						class="tify-info_toggle"
-						@click="infoItems[index].isCollapsed = !infoItems[index].isCollapsed"
-					>
-						<template v-if="!infoItems || (infoItems && infoItems[index] && infoItems[index].isCollapsed)">
-							<icon name="expand_more"/>
-							{{ 'Expand'|trans }}
-						</template>
-						<template v-else>
-							<icon name="expand_less"/>
-							{{ 'Collapse'|trans }}
-						</template>
-					</button>
+			<h4>
+				<div v-bind:key="index" v-for="(label, index) in getLabels(item.label)">
+					{{ label|cleanLabel }}
 				</div>
-			</template>
+			</h4>
+			<div
+				class="tify-info_content"
+				:class="{ '-collapsed': infoItems[index] && infoItems[index].collapsed }"
+				ref="contents"
+			>
+				<div class="tify-info_value">
+					<div v-bind:key="value" v-for="value in getLabels(item.value)" v-html="value"/>
+				</div>
+
+				<button
+					v-if="infoItems[index] && infoItems[index].exceedsHeight"
+					class="tify-info_toggle"
+					@click="infoItems[index].collapsed = !infoItems[index].collapsed"
+				>
+					<template v-if="infoItems[index].collapsed">
+						<icon name="expand_more"/>
+						{{ 'Expand'|trans }}
+					</template>
+					<template v-else>
+						<icon name="expand_less"/>
+						{{ 'Collapse'|trans }}
+					</template>
+				</button>
+			</div>
 		</div>
 	</div>
 </template>
 
 <script>
-const itemMaxLines = 5;
-const lineHeight = 24; // [px] value from settings.scss
-const maxCharsPerLine = 42; // value empirically determined (and checked against zooming in)
-
 export default {
 	props: [
 		'metadata',
 	],
 	data() {
 		return {
-			infoItems: null,
+			infoItems: [],
 		};
 	},
 	watch: {
 		metadata() {
-			this.updateInfoItems();
+			this.$nextTick(() => this.updateInfoItems());
 		},
 	},
 	filters: {
@@ -66,33 +60,24 @@ export default {
 	},
 	methods: {
 		updateInfoItems() {
-			const itemMaxHeight = itemMaxLines * lineHeight;
-			this.collapsedStyle = `max-height: ${itemMaxHeight}px; overflow: hidden`;
+			this.$refs.contents.forEach((content, index) => {
+				const fullHeight = content.offsetHeight;
 
-			const infoItems = [];
-			const { length } = Object.values(this.metadata);
-			for (let i = 0; i < length; i += 1) {
-				const item = this.metadata[i];
-				const values = this.$root.convertValueToArray(item.value);
+				this.$set(this.infoItems, index, {
+					collapsed: true,
+					exceedsHeight: true,
+				});
 
-				const expectedLineNumber = values.reduce((linesSum, thisValue) => {
-					// assuming we need 1 line minimum to display each value
-					// and a fixed number of chars fits into each line
-					let nLines = Math.ceil(this.stripHtml(thisValue).length / maxCharsPerLine);
-					if (nLines < 1) {
-						nLines = 1;
-					}
+				this.$nextTick(() => {
+					const collapsedHeight = content.offsetHeight;
+					const shouldBeCollapsed = fullHeight >= collapsedHeight;
 
-					return linesSum + nLines;
-				}, 0);
-				const limitHeight = (expectedLineNumber > itemMaxLines);
-				const infoItem = {
-					isCollapsed: limitHeight,
-					isInitiallyCollapsed: limitHeight,
-				};
-				infoItems.push(infoItem);
-			}
-			this.infoItems = infoItems;
+					this.$set(this.infoItems, index, {
+						collapsed: shouldBeCollapsed,
+						exceedsHeight: shouldBeCollapsed,
+					});
+				});
+			});
 		},
 		stripHtml(html) {
 			const doc = new DOMParser().parseFromString(html, 'text/html');

--- a/src/styles/views/info.scss
+++ b/src/styles/views/info.scss
@@ -1,3 +1,5 @@
+$info-content-max-height: g(6.5);
+
 .tify-info {
 	@extend %panel;
 	overflow-y: auto;
@@ -8,14 +10,7 @@
 	position: relative;
 
 	&.-collapsed {
-		&::after {
-			background: linear-gradient(rgba(#fff, 0), rgba(#fff, 1));
-			bottom: 0;
-			content: '';
-			height: 40%;
-			position: absolute;
-			width: 100%;
-		}
+		max-height: $info-content-max-height;
 	}
 }
 
@@ -40,5 +35,26 @@
 
 .tify-info_toggle {
 	@extend %button-small;
-	margin: g(.25) 0 0;
+	margin: g(.5) 0;
+	position: relative;
+}
+
+.tify-info_value {
+	> div:last-child > :last-child {
+		margin-bottom: 0;
+	}
+
+	.tify-info_content.-collapsed & {
+		max-height: $info-content-max-height - g(2); // 2 = button height
+		overflow: hidden;
+
+		&::after {
+			background: linear-gradient(rgba(#fff, 0), rgba(#fff, 1));
+			bottom: g(2); // 2 = button height
+			content: '';
+			height: g(2);
+			position: absolute;
+			width: 100%;
+		}
+	}
 }

--- a/src/views/Info.vue
+++ b/src/views/Info.vue
@@ -100,11 +100,6 @@ export default {
 	mixins: [
 		structures,
 	],
-	data() {
-		return {
-			collapsedStyle: '',
-		};
-	},
 	computed: {
 		license() {
 			return this.manifest.license ? this.getLabels(this.manifest.license) : [];


### PR DESCRIPTION
Instead of using an "empirically determined" value, check the height of each element and determine if collapsing it and adding a button actually saves space. The maximum height is now set via stylesheet.