### PR TITLE
Fix "ready" state for viewer API

### DIFF
--- a/src/components/ViewScan.vue
+++ b/src/components/ViewScan.vue
@@ -165,6 +165,7 @@ import vClickOutside from 'click-outside-vue3';
 import OpenSeadragon from 'openseadragon';
 
 import { preventEvent } from '../modules/keyboard';
+import { createPromise } from '../modules/promise';
 
 const gapBetweenPages = 0.01;
 
@@ -176,6 +177,7 @@ export default {
 		return {
 			filtersVisible: false,
 			loadingTimeout: null,
+			promise: createPromise(),
 			tileSources: {},
 			viewer: null,
 			viewerState: {}, // NOTE: See updateViewerState()
@@ -201,6 +203,8 @@ export default {
 	mounted() {
 		this.loadImageInfo();
 		this.updateFilterStyle();
+
+		this.$store.readyPromises.push(this.promise);
 
 		// TODO: Add a function for adding/removing global event listeners
 		this.$store.rootElement.addEventListener('keydown', this.onKeydown);
@@ -387,6 +391,8 @@ export default {
 
 			this.$api.expose(this.resetScan);
 			this.$api.expose(this.viewer, 'viewer');
+
+			this.promise.resolve();
 		},
 		loadImageInfo(reset = false) {
 			this.stopLoadingWatch();

--- a/src/modules/promise.js
+++ b/src/modules/promise.js
@@ -1,0 +1,14 @@
+export function createPromise() {
+	let resolveFunction;
+	let rejectFunction;
+
+	const promise = new Promise((resolve, reject) => {
+		resolveFunction = resolve;
+		rejectFunction = reject;
+	});
+
+	promise.resolve = resolveFunction;
+	promise.reject = rejectFunction;
+
+	return promise;
+}

--- a/tests/e2e/api.spec.js
+++ b/tests/e2e/api.spec.js
@@ -6,6 +6,9 @@ describe('API', () => {
 
 		cy.window().its('tify').then((tify) => {
 			tify.ready.then(() => {
+				tify.viewer.viewport.zoomTo(2);
+				cy.contains('Zoom in').should('be.disabled');
+
 				tify.setLanguage('de');
 				cy.contains('Seiten');
 


### PR DESCRIPTION
Add promise creator so every component can define ready conditions, use it in scan component so "ready" is only fulfilled after viewer has been initialized.

Resolves #164