### PR TITLE
Gracefully handle a missing translation

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,16 +149,21 @@
 		// Restore instances from URL query
 		window.onload = () => {
 			const url = new URL(window.location);
-			for (const params of url.searchParams) {
-				if (!params[0].startsWith('manifest')) {
+			for (const [key, value] of url.searchParams) {
+				if (key.startsWith('language')) {
+					const id = parseInt(key.replace('language', ''), 10) || '';
+					instances.find(instance => instance.id === id).tify.setLanguage(value)
+				}
+
+				if (!key.startsWith('manifest')) {
 					continue
 				}
 
-				const key = parseInt(params[0].replace('manifest', ''), 10) || '';
+				const id = parseInt(key.replace('manifest', ''), 10) || '';
 				addInstance({
-					key,
-					manifestUrl: params[1],
-					urlQueryKey: `tify${key}`,
+					id,
+					manifestUrl: value,
+					urlQueryKey: `tify${id}`,
 				});
 			}
 		};
@@ -167,17 +172,17 @@
 			element = template.cloneNode(true);
 			main.append(element);
 
-			let key = options.key || '';
-			while (instances.find(instance => instance.key === key)) {
-				key = (key || 0) + 1;
+			let id = options.id || '';
+			while (instances.find(instance => instance.id === id)) {
+				id = (id || 0) + 1;
 			}
 
 			tifyOptions.container = element.querySelector('.instance-tify');
 			tifyOptions.manifestUrl = options.manifestUrl || manifestUrlInput.value;
-			tifyOptions.urlQueryKey = options.urlQueryKey || `tify${key}`;
+			tifyOptions.urlQueryKey = options.urlQueryKey || `tify${id}`;
 
 			const tify = new Tify(tifyOptions);
-			const instance = { element, key, tify };
+			const instance = { element, id, tify };
 			instances.push(instance);
 
 			// Expose API of lastest instance for e2e tests
@@ -188,7 +193,7 @@
 			// Update URL query if manifest was set via input
 			if (!options.manifestUrl) {
 				const url = new URL(window.location);
-				url.searchParams.append(`manifest${key}`, tifyOptions.manifestUrl);
+				url.searchParams.append(`manifest${id}`, tifyOptions.manifestUrl);
 				window.history.pushState(null, '', url.toString());
 			}
 		}
@@ -197,11 +202,12 @@
 			instanceToRemove.element.remove();
 			instanceToRemove.tify.destroy();
 
-			instances.splice(instances.findIndex(instance => instance.key === instanceToRemove.key), 1);
+			instances.splice(instances.findIndex(instance => instance.id === instanceToRemove.id), 1);
 
 			const url = new URL(window.location);
-			url.searchParams.delete(`manifest${instanceToRemove.key}`);
-			url.searchParams.delete(`tify${instanceToRemove.key}`);
+			url.searchParams.delete(`language${instanceToRemove.id}`);
+			url.searchParams.delete(`manifest${instanceToRemove.id}`);
+			url.searchParams.delete(`tify${instanceToRemove.id}`);
 			window.history.pushState(null, '', url.toString());
 		}
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -167,9 +167,10 @@ export default {
 				this.$translate.setTranslation(loadedTranslation);
 				promise.resolve(language);
 			}, (error) => {
+				// Allow the promise to resolve, but display an error message and keep the previous language
 				const status = error.response ? error.response.statusText : error.message;
 				this.$store.addError(`Error loading translation for "${language}": ${status}`);
-				promise.reject(new Error(error));
+				promise.resolve(this.$store.options.language);
 			});
 
 			return promise;

--- a/tests/e2e/main.spec.js
+++ b/tests/e2e/main.spec.js
@@ -19,4 +19,24 @@ describe('Main', () => {
 		cy.visit(`/?manifest=${Cypress.env('iiifApiUrl')}/manifest/not-json`);
 		cy.contains('Error loading IIIF manifest');
 	});
+
+	it('loads a translation', () => {
+		cy.visit(`/?manifest=${Cypress.env('iiifApiUrl')}/manifest/gdz-PPN857449303&language=de`);
+
+		cy.get('.tify-header');
+		cy.contains('Seiten');
+		cy.contains('Inhalt');
+	});
+
+	it('gracefully handles a missing translation', () => {
+		// Prevent the test from failing due to an uncaught exception (which is expected)
+		cy.on('uncaught:exception', () => false);
+
+		cy.visit(`/?manifest=${Cypress.env('iiifApiUrl')}/manifest/gdz-PPN857449303&language=nope`);
+
+		cy.get('.tify-header');
+		cy.contains('Pages');
+		cy.contains('Contents');
+		cy.contains('Error loading translation for "nope"');
+	});
 });


### PR DESCRIPTION
If a translation file cannot be loaded, display an error message and keep the previous language. Allow setting the language via URL query for testing.

Resolves #170