### PR TITLE
Fix collection view for IIIF 2

### DIFF
--- a/src/components/CollectionNode.vue
+++ b/src/components/CollectionNode.vue
@@ -1,7 +1,7 @@
 <template>
 	<li
 		class="tify-collection-item"
-		:class="{ '-current': $store.manifest && $store.manifest.id === item.id }"
+		:class="{ '-current': $store.manifest && $store.manifest.id === (item['@id'] || item.id) }"
 	>
 		<button
 			v-if="item.type === 'Collection'"
@@ -87,7 +87,7 @@ export default {
 				return;
 			}
 
-			this.$store.fetchJson(this.item.id).then(
+			this.$store.fetchJson(this.item['@id'] || this.item.id).then(
 				(childManifest) => {
 					this.children = childManifest.collections || childManifest.items || childManifest.manifests || [];
 					this.expanded = true;

--- a/tests/e2e/collection.spec.js
+++ b/tests/e2e/collection.spec.js
@@ -40,4 +40,12 @@ describe('Collection', () => {
 		cy.contains('15. October 1859').click();
 		cy.contains('h1', 'The chemist and druggist, 15. October 1859');
 	});
+
+	it('highlights the current child manifest', () => {
+		cy.visit(`/?manifest=${Cypress.env('iiifApiUrl')}/manifest/wellcome-b19974760`);
+
+		cy.contains('Volume 1').click();
+		cy.contains('15. September 1859').click();
+		cy.contains('.tify-collection-item.-current', '15. September 1859');
+	});
 });


### PR DESCRIPTION
Highlight the currently loaded child manifest in collection view for IIIF 2 collections. Also use `@id` for loading child manifests.