### PR TITLE
Fix setting language via API

### DIFF
--- a/src/plugins/i18n.js
+++ b/src/plugins/i18n.js
@@ -1,11 +1,13 @@
+import { ref } from 'vue';
+
 export default {
 	install: (app) => {
-		let translation = null;
+		const translation = ref(null);
 
 		// eslint-disable-next-line no-param-reassign
 		app.config.globalProperties.$translate = (string, fallback) => {
-			if (translation && translation[string]) {
-				return translation[string];
+			if (translation.value?.[string]) {
+				return translation.value[string];
 			}
 
 			if (import.meta.env.DEV && translation) {
@@ -21,7 +23,7 @@ export default {
 		// value is the translated string, e.g. { key: 'Schlüssel' }
 		// eslint-disable-next-line no-param-reassign
 		app.config.globalProperties.$translate.setTranslation = (translationObject) => {
-			translation = translationObject;
+			translation.value = translationObject;
 		};
 	},
 };


### PR DESCRIPTION
When using `setLanguage`, the new language was only applied after the next render update due to missing reactivity.