### PR TITLE
Fix page select styles

### DIFF
--- a/src/styles/sections/header.scss
+++ b/src/styles/sections/header.scss
@@ -22,6 +22,7 @@
 	position: relative;
 
 	&.-page-select {
+		align-items: stretch;
 		align-self: center;
 		border-radius: $br;
 		margin: 0;

--- a/src/styles/sections/page-select.scss
+++ b/src/styles/sections/page-select.scss
@@ -1,7 +1,8 @@
 .tify-page-select {
 	> .tify-dropdown-button {
 		@extend %button;
-		line-height: 1;
+		height: 100%;
+		line-height: 1.5;
 		max-width: g(5);
 		min-width: g(3);
 		overflow: hidden;


### PR DESCRIPTION
Fix cut-off descenders in button label. Ensure both buttons have the same height regardless of font size.

Test with https://tify-iiif-viewer.github.io/tify/fix-page-select-styles/?manifest=https%3A%2F%2Fiiif.bodleian.ox.ac.uk%2Fiiif%2Fmanifest%2Fe32a277e-91e2-4a6d-8ba6-cc4bad230410.json&tify=%7B%22pages%22%3A%5B7%5D%7D, check `Sepoys` in page select. Adjust font size in devtools and check if button height matches.

Compare with https://tify-iiif-viewer.github.io/tify/?manifest=https%3A%2F%2Fiiif.bodleian.ox.ac.uk%2Fiiif%2Fmanifest%2Fe32a277e-91e2-4a6d-8ba6-cc4bad230410.json&tify=%7B%22pages%22%3A%5B7%5D%7D, where `[` and letters are cut off at the buttom.