### PR TITLE
Add support for provider seeAlso

### DIFF
--- a/src/components/ViewInfo.vue
+++ b/src/components/ViewInfo.vue
@@ -281,11 +281,11 @@ export default {
 					{{ $store.localize(provider.label) }}
 				</p>
 				<ul
-					v-if="provider.homepage?.length"
+					v-if="provider.homepage?.length || provider.seeAlso?.length"
 					class="tify-list"
 				>
 					<li
-						v-for="homepage in provider.homepage"
+						v-for="homepage in [...provider.homepage || [], ...provider.seeAlso || []]"
 						:key="homepage.id"
 					>
 						<a :href="homepage.id">

--- a/tests/e2e/iiif-cookbook/0234-provider.spec.js
+++ b/tests/e2e/iiif-cookbook/0234-provider.spec.js
@@ -1,0 +1,21 @@
+describe('IIIF Cookbook 0234: Provider', () => {
+	it('displays all provider information', () => {
+		cy.visit(
+			`/?manifest=${Cypress.env('iiifApiUrl')}/iiif-cookbook/0234-provider/manifest.json`
+			+ '&tify={"view":"info"}',
+		);
+
+		cy.contains(
+			'.tify-info-section.-provider p',
+			'UCLA Library',
+		);
+		cy.contains(
+			'.tify-info-section.-provider a',
+			'UCLA Library Digital Collections',
+		);
+		cy.contains(
+			'.tify-info-section.-provider a[href$="n79055331.madsxml.xml"]',
+			'US Library of Congress data about the UCLA Library',
+		);
+	});
+});


### PR DESCRIPTION
Check https://tify-iiif-viewer.github.io/tify/262/?manifest=https%3A%2F%2Ftify.rocks%2Fmanifests%2Fiiif-cookbook-collection.json&tify=%7B%22childManifestUrl%22%3A%22https%3A%2F%2Fiiif.io%2Fapi%2Fcookbook%2Frecipe%2F0234-provider%2Fmanifest.json%22%2C%22view%22%3A%22info%22%7D. There are now two links under “Provided by”, the second one from `seeAlso`.