### PR TITLE
Fix handling of non-paged pages in double-page view

### DIFF
--- a/tests/e2e/iiif-cookbook/0035-foldouts.spec.js
+++ b/tests/e2e/iiif-cookbook/0035-foldouts.spec.js
@@ -20,12 +20,21 @@ describe('IIIF Cookbook 0025: Foldout as separate page in double-page view', () 
 
 		cy.get('[title="Next page"]').eq(0).click();
 		cy.get('.tify-thumbnails-item.-current:nth-child(5)');
-		cy.get('.tify-thumbnails-item.-current').should('have.length', 1);
+		cy.get('.tify-thumbnails-item.-current:nth-child(6)');
+		cy.get('.tify-thumbnails-item.-current').should('have.length', 2);
 
 		cy.get('[title="Next page"]').eq(0).click();
-		cy.get('.tify-thumbnails-item.-current:nth-child(6)');
 		cy.get('.tify-thumbnails-item.-current:nth-child(7)');
+		cy.get('.tify-thumbnails-item.-current:nth-child(8)');
 		cy.get('.tify-thumbnails-item.-current').should('have.length', 2);
+
+		cy.get('[title="Next page"]').eq(0).click();
+		cy.get('.tify-thumbnails-item.-current:nth-child(9)');
+		cy.get('.tify-thumbnails-item.-current').should('have.length', 1);
+
+		cy.get('[title="Previous page"]').eq(0).click().click();
+		cy.get('.tify-thumbnails-item.-current:nth-child(5)');
+		cy.get('.tify-thumbnails-item.-current:nth-child(6)');
 
 		cy.contains('.tify-thumbnails-item', 'Foldout, unfolded').click();
 		cy.get('.tify-thumbnails-item.-current:nth-child(4)');


### PR DESCRIPTION
Check https://tify-iiif-viewer.github.io/tify/264/?manifest=https%3A%2F%2Ftify.rocks%2Fmanifests%2Fiiif-cookbook-collection.json&tify=%7B%22childManifestUrl%22%3A%22https%3A%2F%2Fiiif.io%2Fapi%2Fcookbook%2Frecipe%2F0035-foldouts%2Fmanifest.json%22%2C%22pages%22%3A%5B-1%2C4%5D%7D. For all following pages, the even/odd order is reversed (5 is verso, 6 is recto) due to one non-paged page (“foldout”).