### PR TITLE
Fix error when info file fails to load

### DIFF
--- a/src/components/ViewMedia.vue
+++ b/src/components/ViewMedia.vue
@@ -482,7 +482,7 @@ export default {
 					// pages or on slow connections, promises could resolve when the
 					// corresponding pages are no longer displayed.
 					const pages = this.$store.options.pages.filter((page) => page > 0);
-					if (pages.every((page, index) => infoItems[index].$meta.page === page)) {
+					if (pages.every((page, index) => infoItems[index]?.$meta.page === page)) {
 						this.initViewer(reset);
 					}
 				});


### PR DESCRIPTION
Test with https://tify-iiif-viewer.github.io/tify/266/?manifest=https://purl.stanford.edu/md338fq3060/iiif/manifest. There should only be network errors logged to console, but no uncaught `TypeError`.