### PR TITLE
API: add getPageCount() method

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -44,6 +44,10 @@ tify.ready.then(() => {
 
 		By default, only pan and zoom are reset. If `true`, image filters and rotation are reset, too.
 
+- **`getPageCount`**
+
+	Returns the number of pages in the presentation.
+
 - **`setPage`**
 
 	Changes the active page or pages.

--- a/src/App.vue
+++ b/src/App.vue
@@ -42,6 +42,7 @@ export default {
 	},
 	created() {
 		this.$api.expose(this.setLanguage);
+		this.$api.expose(this.$store.getPageCount);
 		this.$api.expose(this.$store.setPage);
 		this.$api.expose(this.$store.updateOptions);
 	},

--- a/src/plugins/store.js
+++ b/src/plugins/store.js
@@ -333,6 +333,7 @@ function Store(args = {}) {
 				? page + 1
 				: 0;
 		},
+		getPageCount: () => store.pageCount,
 		getPageLabel(number, labelObject) {
 			const label = store.localize(labelObject, '');
 


### PR DESCRIPTION
Our designers have a need for displaying the total page count on the page. I figured out you can get it like this:

```js
    tify = new Tify();
    tify.ready.then(() => {
        console.log(tify.app.config.globalProperties.$store.pageCount);
    });
```

But I thought it would be nice to have an easier to use method for this.