### PR TITLE
Dispatch a page-change event embedders can observe

### DIFF
--- a/src/plugins/store.js
+++ b/src/plugins/store.js
@@ -753,6 +753,17 @@ function Store(args = {}) {
 			}
 
 			store.updateOptions({ pages });
+
+			// Lets embedders (e.g. pb-tify) react to page changes regardless of
+			// origin (external API call vs. in-viewer navigation), since there is
+			// no other way to observe that distinction from outside the instance.
+			if (store.rootElement) {
+				store.rootElement.dispatchEvent(new CustomEvent('tify-page-change', {
+					detail: { pages },
+					bubbles: true,
+				}));
+			}
+
 			return pages;
 		},
 		toggleAnnotationId(annotationId) {


### PR DESCRIPTION
## Summary

`setPage()` has no way for external code to distinguish "I called
`setPage()` myself" from "the user navigated within the viewer." The only
thing exposed publicly is `tify.setPage` — a copied function reference, not
the live store method — so patching that alias only catches calls that go
through it. Internal navigation (thumbnails, TOC, pagination buttons) calls
the store's own `setPage()` directly and never touches the alias, so
embedders have no reliable way to know when the visible page actually
changed.

This dispatches a `tify-page-change` `CustomEvent` on `rootElement` from
`store.setPage()` instead, so an embedder can listen for real page changes
regardless of where the navigation originated.

## Motivation

Raised while updating `eeditiones/tei-publisher-components`'s `pb-tify.js`
to Tify 0.35 — it needs to re-fire its own `pb-refresh` event whenever the
user navigates within the viewer (not just when it calls `setPage` itself),
which isn't possible against the current public API once it moves off
0.28's Vue-2-era internals (reaching into `app.$root`, etc.).

## Testing

Verified with a real `addEventListener('tify-page-change', ...)` listener
firing correctly on in-viewer navigation (thumbnail click) — the
alias-patching approach could not detect this at all.

## Scope note

This is deliberately independent of the `feature/imageapiselector-rotation`
branch/PR — different file (`src/plugins/store.js` only), no shared code,
so it can be reviewed/merged on its own regardless of what happens with
that one.
