### PR TITLE
harden: the thumbnail generation script accepts user-co... in...

### DIFF
--- a/build/create-iiif-thumbnails.js
+++ b/build/create-iiif-thumbnails.js
@@ -16,6 +16,28 @@ const thumbnailWidth = 240;
 const thumbnailHeight = 240;
 const thumbnailOverflow = 8;
 
+// Blocks fetches to loopback, link-local and private-network hosts to prevent SSRF
+const blockedHostnamePatterns = [
+	/^localhost$/i,
+	/^127\./,
+	/^10\./,
+	/^172\.(1[6-9]|2\d|3[0-1])\./,
+	/^192\.168\./,
+	/^169\.254\./,
+	/^\[?::1\]?$/,
+	/^0\.0\.0\.0$/,
+];
+
+function isAllowedManifestUrl(url) {
+	try {
+		const { protocol, hostname } = new URL(url);
+		return (protocol === 'http:' || protocol === 'https:')
+			&& !blockedHostnamePatterns.some((pattern) => pattern.test(hostname));
+	} catch {
+		return false;
+	}
+}
+
 if (!fs.existsSync(thumbnailsDir)) {
 	fs.mkdirSync(thumbnailsDir, { recursive: true });
 }
@@ -31,6 +53,10 @@ async function saveThumbnail(manifestUrl, parentUrl = '') {
 	}
 
 	// Fetch IIIF manifest
+	if (!isAllowedManifestUrl(manifestUrl)) {
+		return { error: 'Manifest URL is not allowed' };
+	}
+
 	let manifestRes;
 	try {
 		manifestRes = await fetch(manifestUrl);


### PR DESCRIPTION
## Summary
Harden input handling in `build/create-iiif-thumbnails.js` (flagged by multi_agent_ai).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `build/create-iiif-thumbnails.js:36` |
| **Assessment** | Defensive hardening |

**Description**: The thumbnail generation script accepts user-controllable manifest URLs without validation. Attackers who can influence the manifestUrl parameter can supply URLs pointing to internal resources (localhost, private IP ranges, cloud metadata endpoints) that the server-side fetch() will access.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `build/create-iiif-thumbnails.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
