### PR TITLE
Change color mode behavior

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,9 @@
 # Upgrading TIFY
 
+## v0.36
+
+- The default `colorMode: 'auto'` now follows the host website’s `color-scheme` instead of the browser preference. Use `colorMode: 'system'` for the previous behavior.
+
 ## v0.35
 
 No breaking changes.

--- a/src/config.js
+++ b/src/config.js
@@ -52,13 +52,14 @@ export default {
 	/**
 	 * Determines if TIFY is displayed in light or dark mode.
 	 *
-	 * `light`: Use light mode, regardless of browser preferences.
-	 * `dark`: Use dark mode, regardless of browser preferences.
-	 * `auto`: Determine color mode automatically based on browser preferences.
+	 * `auto`: Determine color mode based on the host website’s `color-scheme`.
+	 * `dark`: Use dark mode, regardless of browser preference.
+	 * `light`: Use light mode, regardless of browser preference.
+	 * `system`: Determine color mode based on browser preference.
 	 *
 	 * @type {string}
 	 */
-	colorMode: 'light',
+	colorMode: 'auto',
 
 	/**
 	 * The HTML element into which TIFY is mounted. If not set, TIFY is not

--- a/src/demo/DemoApp.vue
+++ b/src/demo/DemoApp.vue
@@ -111,7 +111,7 @@ export default {
 			v-for="instance in instances"
 			:key="instance.id"
 			class="instance"
-			:style="`color-scheme: ${instance.colorMode === 'auto' ? 'light dark' : instance.colorMode}`"
+			:style="`color-scheme: ${instance.colorMode === 'system' ? 'light dark' : instance.colorMode}`"
 		>
 			<DemoHeader
 				:instance="instance"

--- a/src/demo/Instance.class.js
+++ b/src/demo/Instance.class.js
@@ -2,7 +2,7 @@
 
 export default class Instance {
 	constructor(options = {}) {
-		this.colorMode = 'auto'; // TODO: Store in URL?
+		this.colorMode = 'system'; // TODO: Store in URL?
 		this.hasContentState = !!(new URL(window.location)).searchParams.get('iiif-content');
 		this.id = options.id;
 		this.language = options.language || 'en';

--- a/src/demo/components/ColorModeSwitcher.vue
+++ b/src/demo/components/ColorModeSwitcher.vue
@@ -11,7 +11,7 @@ export default {
 	],
 	methods: {
 		getLabel(colorMode) {
-			if (colorMode === 'auto') {
+			if (colorMode === 'system') {
 				return this.$translate('automatic', this.instance);
 			}
 
@@ -31,7 +31,7 @@ export default {
 		role="toolbar"
 	>
 		<li
-			v-for="colorMode in ['auto', 'light', 'dark']"
+			v-for="colorMode in ['system', 'light', 'dark']"
 			:key="colorMode"
 		>
 			<button
@@ -41,7 +41,7 @@ export default {
 				:title="getLabel(colorMode)"
 				@click="$emit('change', colorMode)"
 			>
-				<IconThemeLightDark v-if="colorMode === 'auto'" />
+				<IconThemeLightDark v-if="colorMode === 'system'" />
 				<IconWeatherSunny v-else-if="colorMode === 'light'" />
 				<IconWeatherNight v-else />
 			</button>

--- a/src/styles/util/base.scss
+++ b/src/styles/util/base.scss
@@ -2,7 +2,6 @@
 	background: $main-bg;
 	box-sizing: border-box;
 	color: $text-color;
-	color-scheme: light dark;
 	container-type: size;
 	display: flex;
 	flex-direction: column;
@@ -15,12 +14,16 @@
 	position: relative;
 	-webkit-tap-highlight-color: transparent;
 
+	&.-dark {
+		color-scheme: dark;
+	}
+
 	&.-light {
 		color-scheme: light;
 	}
 
-	&.-dark {
-		color-scheme: dark;
+	&.-system {
+		color-scheme: light dark;
 	}
 
 	*,


### PR DESCRIPTION
Change default `colorMode` back to `auto`, which now means to follow the host website’s `color-scheme` instead of the browser preference. Add `system` setting.